### PR TITLE
Probability percentage approximation from the configured zScore

### DIFF
--- a/confidence.js
+++ b/confidence.js
@@ -230,7 +230,7 @@
   // Gets Confidence percentage from the configured zscore
   Confidence.prototype.getConfidencePercent = function() {
     var normalProbability = zScoreProbability(this._zScore);
-    return Math.round(100 * (2 * normalProbability - 1));
+    return (100 * (2 * normalProbability - 1)).toFixed(2);
   }
 
   // Are these result statistically significant?


### PR DESCRIPTION
95% is the confidence for a zscore of 1.96, but if this is configured to be another z value the message will be incorrect as it changes this percentage.

The private zScoreProbability method is adapted from a polynomial approximation in:
    Ibbetson D, Algorithm 209
    Collected Algorithms of the CACM 1963 p. 616
